### PR TITLE
Remove Cache Path Setting from Settings Page

### DIFF
--- a/inc/Cacher.php
+++ b/inc/Cacher.php
@@ -75,26 +75,10 @@ class Cacher extends \WP_Fragment_HTML_Cache {
 	public function get_cache_path( $append = null ) {
 		$path = trailingslashit( WP_CONTENT_DIR . '/cache/' . $this->slug );
 
-		/*
-		 * Get override path from settings.
-		 *
-		 * This still uses the WP_CONTENT_DIR to prevent unintended paths by less-advanced users.
-		 *
-		 * This path can be completely overriden using the wp_static_menus_cache_path filter below.
-		 */
-		$settings_path = Settings::get_instance()->get_value( 'cache_path' );
-		if ( ! empty( $settings_path ) && is_string( $settings_path ) ) {
-
-			// Normalize the settings path.
-			$settings_path = wp_normalize_path( $settings_path );
-
-			// Wp_normalize_path allows slashes at the start of the string.
-			$settings_path = ltrim( $settings_path, '/' );
-			$path          = trailingslashit( WP_CONTENT_DIR ) . trailingslashit( $settings_path );
-		}
-
 		/**
 		 * Filter the cache directory path.
+		 *
+		 * Be careful, because this can be *very* destructive!
 		 *
 		 * Defaults to 'wp-content/cache/wp-static-menus/'.
 		 *

--- a/inc/Settings.php
+++ b/inc/Settings.php
@@ -4,8 +4,6 @@
  *
  * Renders the settings page and saves settings into an option.
  *
- * @todo Testing: Consider ways to set/get option value when this is a singleton.
- *
  * @package Mindsize\WPStaticMenus
  * @since   0.1.0
  * @author  Mindsize <info@mindsize.me>
@@ -162,13 +160,7 @@ class Settings {
 	 * @action admin_init
 	 */
 	public function register_settings() {
-		register_setting(
-			self::SETTING,
-			self::OPTION_NAME,
-			[
-				'sanitize_callback' => [ $this, 'sanitize_settings' ],
-			]
-		);
+		register_setting( self::SETTING, self::OPTION_NAME );
 
 		add_settings_section(
 			'config',
@@ -191,21 +183,6 @@ class Settings {
 			[ $this, 'exceptions_render' ],
 			self::SETTING,
 			'config'
-		);
-
-		add_settings_section(
-			'overrides',
-			esc_html__( 'Overrides', 'wp-static-menus' ),
-			[ $this, 'overrides_intro' ],
-			self::SETTING
-		);
-
-		add_settings_field(
-			'cache_path',
-			__( 'Cache Directory', 'wp-static-menus' ) . '<p style="font-weight: normal;">Where the cache files are stored within /wp-content/</p>',
-			[ $this, 'cache_path_render' ],
-			self::SETTING,
-			'overrides'
 		);
 
 		add_settings_section(
@@ -308,30 +285,6 @@ class Settings {
 	}
 
 	/**
-	 * Intro text to the Overrides section.
-	 */
-	public function overrides_intro() {
-		echo wp_kses_post( '<hr>' );
-	}
-
-	/**
-	 * Render the Cache Path field.
-	 */
-	public function cache_path_render() {
-		$value      = $this->get_value( 'cache_path' );
-		$field_name = self::OPTION_NAME . '[cache_path]';
-
-		?>
-		<fieldset id="cache-path">
-			<input class="widefat" style="width: 500px; max-width: 100%;" type="text" name="<?php echo esc_attr( $field_name ); ?>" value="<?php echo esc_html( $value ); ?>" placeholder="cache/wp-static-menus/" /><br>
-		</fieldset>
-		<p class="description">
-			<?php echo wp_kses_post( __( 'Default: cache/wp-static-menus/', 'wp-static-menus' ) ); ?>
-		</p>
-		<?php
-	}
-
-	/**
 	 * Intro text to the Tools section.
 	 */
 	public function cache_tools_intro() {
@@ -392,43 +345,6 @@ class Settings {
 				</form>
 		</div>
 		<?php
-	}
-
-	/**
-	 * Sanitize our settings option.
-	 *
-	 * The real purpose of this is to clear the cache_path if it is changed.
-	 *
-	 * @param array $input The option to be saved.
-	 *
-	 * @return array The sanitized option.
-	 */
-	public function sanitize_settings( $input ) {
-
-		// If cache_path has changed, empty the current cache_path directory.
-		$existing_cache_path = $this->get_value( 'cache_path' );
-		$new_cache_path      = ( isset( $input['cache_path'] ) ) ? $input['cache_path'] : false;
-		if ( $new_cache_path !== $existing_cache_path ) {
-			$cacher = new Cacher();
-			$cacher->clear_cache();
-		}
-
-		/*
-		 * Normalize the path.
-		 *
-		 * wp_normalize_path() allows slashes at the start of the string.
-		 * We remove those as this setting will only be applied to
-		 * the WP_CONTNENT_DIR, and we don't want to unintentionally
-		 * end up with double slashes in the middle of that path.
-		 *
-		 * Those requiring the double slashes will need to use the
-		 * wp_static_menus_cache_path filter.
-		 */
-		if ( isset( $input['cache_path'] ) ) {
-			$input['cache_path'] = trailingslashit( ltrim( wp_normalize_path( $input['cache_path'] ), '/' ) );
-		}
-
-		return $input;
 	}
 
 	/**


### PR DESCRIPTION
I gave this the ol' college try, but editing this from a settings page proved to have too much destructive power.  It's too easy to accidentally delete one's entire `/wp-content/` directory (not that I would know anything about that 😉)

The filter `wp_static_menus_cache_path` still exists for advanced developers to hook into, but allowing admins to goof with the cache path from a settings page is just too much power.