### PR TITLE
Feature/3 user specific menus

### DIFF
--- a/inc/Cacher.php
+++ b/inc/Cacher.php
@@ -20,6 +20,12 @@ namespace Mindsize\WPStaticMenus;
  */
 class Cacher extends \WP_Fragment_HTML_Cache {
 
+	// Cache transient name.
+	const TRANSIENT_NAME = 'wp_static_menus_cache';
+
+	// Length to hold cache, in minutes.
+	const DEFAULT_CACHE_LENGTH = 60;
+
 	/**
 	 * The slug of this cache class.
 	 *

--- a/inc/Cacher.php
+++ b/inc/Cacher.php
@@ -23,8 +23,8 @@ class Cacher extends \WP_Fragment_HTML_Cache {
 	// Cache transient name.
 	const TRANSIENT_NAME = 'wp_static_menus_cache';
 
-	// Length to hold cache, in minutes.
-	const DEFAULT_CACHE_LENGTH = 60;
+	// Length to hold cache, in seconds.
+	const DEFAULT_CACHE_LENGTH = HOUR_IN_SECONDS;
 
 	/**
 	 * The slug of this cache class.
@@ -72,7 +72,7 @@ class Cacher extends \WP_Fragment_HTML_Cache {
 	/**
 	 * Get the path to the directory where cache files are stored.
 	 *
-	 * Defaults to 'wp-content/cache/wp-static-menus/'.
+	 * Defaults to 'wp-content/wp-static-menus/'.
 	 *
 	 * @param string $append Optional. String to append to the path.
 	 *
@@ -113,7 +113,7 @@ class Cacher extends \WP_Fragment_HTML_Cache {
 		if ( ! $this->is_debug() ) {
 			return;
 		}
-		return __( 'Start WP Static Menus', 'wp-static-menus' );
+		$out = __( 'Start WP Static Menus', 'wp-static-menus' );
 	}
 
 	/**

--- a/inc/Cacher.php
+++ b/inc/Cacher.php
@@ -73,7 +73,7 @@ class Cacher extends \WP_Fragment_HTML_Cache {
 	 * @return string The cache path.
 	 */
 	public function get_cache_path( $append = null ) {
-		$path = trailingslashit( WP_CONTENT_DIR . '/cache/' . $this->slug );
+		$path = trailingslashit( WP_CONTENT_DIR . '/' . $this->slug );
 
 		/**
 		 * Filter the cache directory path.

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -230,6 +230,42 @@ class Plugin {
 	}
 
 	/**
+	 * Filter the Cache Length Setting.
+	 *
+	 * @return int|string Cache length, in seconds.
+	 */
+	public function get_cache_length() {
+
+		// The value from settings is set in minutes for simplicity.
+		$cache_length = $this->settings->get_value( 'cache_length' );
+		if ( empty( $cache_length ) || ! is_numeric( $cache_length ) ) {
+
+			// Defaults to 60 min if setting is empty.
+			$cache_length = 60;
+		}
+
+		// Convert minutes into seconds.
+		$cache_length = intval( $cache_length ) * 60;
+
+		/**
+		 * Override the caching length from the plugin settings.
+		 *
+		 * @todo add $menu_args to this filter.
+		 *
+		 * @param string $method The cache length.
+		 *
+		 * @return string The desired cache length, in seconds.
+		 */
+		$filtered_cache_length = apply_filters( 'wp_static_menus_cache_length', $cache_length );
+
+		if ( ! empty( $filtered_cache_length ) && is_numeric( $filtered_cache_length ) ) {
+			return $filtered_cache_length;
+		}
+
+		return $cache_length;
+	}
+
+	/**
 	 * Empty the Object Cache of our Menus.
 	 *
 	 * @action wp_update_nav_menu
@@ -240,7 +276,7 @@ class Plugin {
 	}
 
 	/**
-	 * Render Admin Notice if WP Fragment Cache plugin not found.
+	 * Render Admin Notice if WP_Fragment_Cache plugin not found.
 	 *
 	 * @action admin_notices
 	 */

--- a/inc/Settings.php
+++ b/inc/Settings.php
@@ -196,6 +196,14 @@ class Settings {
 		);
 
 		add_settings_field(
+			'disable_user_caching',
+			__( 'Disable User Menu Caching', 'wp-static-menus' ),
+			[ $this, 'render_disable_user_caching' ],
+			self::SETTING,
+			'config'
+		);
+
+		add_settings_field(
 			'cache_length',
 			__( 'Cache Length', 'wp-static-menus' ),
 			[ $this, 'render_cache_length' ],
@@ -210,6 +218,7 @@ class Settings {
 			self::SETTING,
 			'config'
 		);
+
 
 		add_settings_section(
 			'cache_tools',
@@ -271,13 +280,29 @@ class Settings {
 				$item_value = isset( $value[ $location ] ) ? 1 : 0;
 				?>
 				<label>
-					<input type="checkbox" name="<?php echo esc_attr( $item_name ); ?>" value="1" <?php checked( $item_value, 1 ); ?>><?php echo esc_html( $description ); ?>
+					<input type="checkbox" name="<?php echo esc_attr( $item_name ); ?>" value="1" <?php checked( $item_value, 1 ); ?>><?php echo esc_html( $description ); ?><br>
 				</label>
 				<br>
 				<?php
 			endforeach;
 			?>
 		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Render the Disable User-level Caching field.
+	 */
+	public function render_disable_user_caching() {
+		$value      = (bool) $this->get_value( 'disable_user_caching' );
+		$field_name = self::OPTION_NAME . '[disable_user_caching]';
+
+		?>
+		<fieldset>
+			<input type="checkbox" name="<?php echo esc_attr( $field_name ); ?>" value="1" <?php checked( $value, 1 ); ?>><?php esc_html_e( 'Disable Menu caching for individual users?', 'wp-static-menus' ); ?>
+			<p class="description"><?php esc_html_e( 'Check this box if your menus do not show user-specific information, like "Edit Profile" links.', 'wp-static-menus' ); ?></p>
+		</fieldset>
+
 		<?php
 	}
 
@@ -319,7 +344,7 @@ class Settings {
 		<p><?php echo wp_kses_post( __( 'Do <span style="text-decoration: underline">not</span> display cached menus to:', 'wp-static-menus' ) ); ?></p>
 		<fieldset>
 			<label>
-				<input type="radio" name="<?php echo esc_attr( $field_name ); ?>" value="logged_in" <?php checked( $value, 'logged_in' ); ?>><?php esc_html_e( 'Any Logged-in User', 'wp-static-menus' ); ?>
+				<input type="radio" name="<?php echo esc_attr( $field_name ); ?>" value="logged_in" <?php checked( $value, 'logged_in' ); ?>><?php esc_html_e( 'Any Logged-in User', 'wp-static-menus' ); ?><br>
 			</label><br>
 			<label>
 				<input type="radio" name="<?php echo esc_attr( $field_name ); ?>" value="admins" <?php checked( $value, 'admins' ); ?>><?php esc_html_e( 'Super Administrators, Administrators, and Editors', 'wp-static-menus' ); ?>


### PR DESCRIPTION
Closes #3 

- [x] Add support for user-level caching of menus
- [x] Add support for clearing the cache periodically (allows Admin to set max cache length)
- [x] Add clearing cache via AJAX in Admin Bar and "Empty Cache" button on Settings Page
- [x] Uses filter hooks to apply Settings (where it makes sense)

By default, the plugin uses user-specific menus to prevent first-time users from serving menus cached from one user to everyone else. Naturally, this feature can be disabled if it isn't necessary from the Settings Page.

These files are named with a hash of the user's ID & email address to prevent anyone guessing what the HTML file is called, which would allow them access to the links available to a specific user.

Uses AJAX to flush cache so that admins can click the link in the admin bar without leaving whatever page they are viewing.

Also, this applies the values from the Settings page via filter hooks just to make things cleaner and easier to work with.